### PR TITLE
Update for newer Rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.7', '3.0' ]
+    name: Ruby ${{ matrix.ruby }} sample
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Setup ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Install bundler deps
+        run: |
+          bundle install
+
+      - name: Run the test
+        run: |
+          bundle exec rake test

--- a/Rakefile
+++ b/Rakefile
@@ -15,8 +15,7 @@ require 'rubygems/package_task'
 
 Rake::TestTask.new('test') do |t|
   t.libs << 'lib'
-  t.pattern = 'test/*_test.rb'
+  t.test_files = FileList['test/*_test.rb']
   t.verbose = true
   t.ruby_opts = ['-r openurl', '-r test/unit']
 end
-

--- a/openurl.gemspec
+++ b/openurl.gemspec
@@ -16,14 +16,17 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = %q{a Ruby library to create, parse and use NISO Z39.88 OpenURLs}
 
-  s.add_development_dependency "bundler", "~> 1.6"
+  s.add_development_dependency "bundler", "~> 2"
   s.add_development_dependency "rake"
+  s.add_development_dependency "test-unit"
 
   # currently needs 'marc' becuase of it's inclusion
   # of the marc referent format, sorry.Should make
   # this optional.
   s.add_dependency "marc"
+
+  s.add_dependency "rexml"
+
   # backfill of String#scrub -- for encoding safety in reading/parsing kev -- in ruby pre 2.1
   s.add_dependency "scrub_rb", "~> 1.0"
 end
-

--- a/test/context_object_test.rb
+++ b/test/context_object_test.rb
@@ -1,10 +1,10 @@
-# encoding: UTF-8
+# encoding: utf-8
 
 Encoding.default_external = "UTF-8" if defined? Encoding
 
 class ContextObjectTest < Test::Unit::TestCase
 
-  def test_create_ctx    
+  def test_create_ctx
     require 'cgi'
     ctx = OpenURL::ContextObject.new
     ctx.referent.set_format('journal')
@@ -21,18 +21,18 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal(ctx.referent.identifiers, ["info:doi/10.1038/nature06100"])
     ctx.referent.add_identifier('info:pmid/17728715')
     assert_equal(ctx.referent.identifiers, ["info:doi/10.1038/nature06100", 'info:pmid/17728715'])
-    assert_equal(ctx.referent.identifier, "info:doi/10.1038/nature06100")    
+    assert_equal(ctx.referent.identifier, "info:doi/10.1038/nature06100")
     ctx.referrer.add_identifier('info:sid/google')
     assert_equal(ctx.referrer.identifier, "info:sid/google")
   end
-  
+
   def test_load_kev
     require 'yaml'
-    data = YAML.load_file('test/test.yml')    
+    data = YAML.load_file('test/test.yml')
     ctx = OpenURL::ContextObject.new_from_kev(data["context_objects"]["kev"])
     self.test_kev_values(ctx)
     ctx = OpenURL::ContextObject.new_from_kev(data["context_objects"]["kev_hybrid"])
-    self.test_kev_hybrid_values(ctx)    
+    self.test_kev_hybrid_values(ctx)
     ctx = OpenURL::ContextObject.new_from_kev(data["context_objects"]["kev_0_1"])
     self.test_kev_01_values(ctx)
   end
@@ -41,17 +41,17 @@ class ContextObjectTest < Test::Unit::TestCase
     params = {"sid" => "elsevier", "isbn" => "dummy"}
     ctx = OpenURL::ContextObject.new_from_form_vars(params)
 
-    assert_equal "info:sid/elsevier", ctx.referrer.identifiers.first, "translate 0.1 style sid into sort-of-legal 1.0 style rfr_id with info:sid URI"    
+    assert_equal "info:sid/elsevier", ctx.referrer.identifiers.first, "translate 0.1 style sid into sort-of-legal 1.0 style rfr_id with info:sid URI"
   end
-  
+
   def test_load_xml
     require 'yaml'
     data = YAML.load_file('test/test.yml')
     xml = File.new(data["context_objects"]["xml_doc"]).read
-    ctx = OpenURL::ContextObject.new_from_xml(xml)  
+    ctx = OpenURL::ContextObject.new_from_xml(xml)
     self.test_xml_values(ctx)
   end
-  
+
   def test_load_form_vals
     require 'yaml'
     require 'cgi'
@@ -69,7 +69,7 @@ class ContextObjectTest < Test::Unit::TestCase
 
     ctx = OpenURL::ContextObject.new_from_form_vars(params)
     rft_metadata = ctx.referent.metadata
-    
+
     assert_equal("Cooper Jr", rft_metadata["aulast"])
     assert_equal("William E", rft_metadata["aufirst"])
     assert_equal("Escape responses of cryptic frogs (Anura: Brachycephalidae: Craugastor) to simulated terrestrial and aerial predators.", rft_metadata["atitle"])
@@ -99,29 +99,29 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal("Abushahba", rft_metadata["aulast"])
     assert_equal("Effect of grafting materials on osseointegration of dental implants surrounded by circumferential bone defects. An experimental study in the dog.", rft_metadata["atitle"])
   end
-  
+
   def test_oai_dc
     require 'yaml'
     data = YAML.load_file('test/test.yml')
     xml = File.new(data["context_objects"]["oai_dc_ctx"]).read
-    ctx = OpenURL::ContextObject.new_from_xml(xml)  
-    self.test_oai_dc_values(ctx)    
+    ctx = OpenURL::ContextObject.new_from_xml(xml)
+    self.test_oai_dc_values(ctx)
     ctx2 = OpenURL::ContextObject.new_from_xml(ctx.xml)
-    self.test_oai_dc_values(ctx2)    
+    self.test_oai_dc_values(ctx2)
   end
-  
+
   def test_marc
     require 'yaml'
     data = YAML.load_file('test/test.yml')
     xml = File.new(data["context_objects"]["marc_21_ctx"]).read
-    ctx = OpenURL::ContextObject.new_from_xml(xml)  
-    self.test_marc_values(ctx)    
+    ctx = OpenURL::ContextObject.new_from_xml(xml)
+    self.test_marc_values(ctx)
     ctx2 = OpenURL::ContextObject.new_from_xml(ctx.xml)
     self.test_marc_values(ctx2)
   end
 
   # Had problems importing a record with an 'au' metadata author.
-  # Fixed it, so adding a test for it. 
+  # Fixed it, so adding a test for it.
   def test_au
     require 'yaml'
     data = YAML.load_file('test/test.yml')
@@ -131,10 +131,10 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal( ctx.referent.metadata["title"], "The adventures of Tom Sawyer")
     assert_equal( ctx.referent.metadata["au"], "Twain, Mark")
   end
-  
+
   def test_xml_output
     require 'yaml'
-    require 'rexml/document'
+
     data = YAML.load_file('test/test.yml')
     ctx = OpenURL::ContextObject.new_from_kev(data["context_objects"]["kev"])
     doc = REXML::Document.new(ctx.xml)
@@ -168,24 +168,24 @@ class ContextObjectTest < Test::Unit::TestCase
     authors_cont = book.elements['rft:authors']
     assert(authors_cont.is_a?(REXML::Element))
     author_cont = authors_cont.elements['rft:author']
-    assert(author_cont.is_a?(REXML::Element))    
+    assert(author_cont.is_a?(REXML::Element))
     assert_equal(author_cont.elements['rft:aulast'].get_text.value, "Vergnaud")
     assert_equal(author_cont.elements['rft:auinit'].get_text.value, "J.-R")
     btitle = book.elements['rft:btitle']
-    assert(btitle.is_a?(REXML::Element))    
+    assert(btitle.is_a?(REXML::Element))
     assert_equal(btitle.get_text.value, "Dépendances et niveaux de représentation en syntaxe")
     genre = book.elements['rft:genre']
     assert(genre.is_a?(REXML::Element))
     assert_equal(genre.get_text.value, "book")
     date = book.elements['rft:date']
     assert(date.is_a?(REXML::Element))
-    assert_equal(date.get_text.value, "1985")    
+    assert_equal(date.get_text.value, "1985")
     pub = book.elements['rft:pub']
     assert(pub.is_a?(REXML::Element))
-    assert_equal(pub.get_text.value, "Benjamins")    
+    assert_equal(pub.get_text.value, "Benjamins")
     place = book.elements['rft:place']
     assert(place.is_a?(REXML::Element))
-    assert_equal(place.get_text.value, "Amsterdam, Philadelphia")  
+    assert_equal(place.get_text.value, "Amsterdam, Philadelphia")
 
     rfe = ctx_obj.elements["ctx:referring-entity"]
     assert(rfe.is_a?(REXML::Element))
@@ -203,40 +203,40 @@ class ContextObjectTest < Test::Unit::TestCase
     authors_cont = book.elements['rfe:authors']
     assert(authors_cont.is_a?(REXML::Element))
     author_cont = authors_cont.elements['rfe:author']
-    assert(author_cont.is_a?(REXML::Element))    
+    assert(author_cont.is_a?(REXML::Element))
     assert_equal(author_cont.elements['rfe:aulast'].get_text.value, "Chomsky")
     assert_equal(author_cont.elements['rfe:auinit'].get_text.value, "N")
     btitle = book.elements['rfe:btitle']
-    assert(btitle.is_a?(REXML::Element))    
+    assert(btitle.is_a?(REXML::Element))
     assert_equal(btitle.get_text.value, "Minimalist Program")
     genre = book.elements['rfe:genre']
     assert(genre.is_a?(REXML::Element))
     assert_equal(genre.get_text.value, "book")
     date = book.elements['rfe:date']
     assert(date.is_a?(REXML::Element))
-    assert_equal(date.get_text.value, "1995")    
+    assert_equal(date.get_text.value, "1995")
     pub = book.elements['rfe:pub']
     assert(pub.is_a?(REXML::Element))
-    assert_equal(pub.get_text.value, "The MIT Press")    
+    assert_equal(pub.get_text.value, "The MIT Press")
     place = book.elements['rfe:place']
     assert(place.is_a?(REXML::Element))
-    assert_equal(place.get_text.value, "Cambridge, Mass")    
+    assert_equal(place.get_text.value, "Cambridge, Mass")
     place = book.elements['rfe:place']
     assert(place.is_a?(REXML::Element))
-    assert_equal(place.get_text.value, "Cambridge, Mass")        
+    assert_equal(place.get_text.value, "Cambridge, Mass")
     isbn = book.elements['rfe:isbn']
     assert(isbn.is_a?(REXML::Element))
-    assert_equal(isbn.get_text.value, "0262531283")       
+    assert_equal(isbn.get_text.value, "0262531283")
     id = rfe.elements['ctx:identifier']
     assert(id.is_a?(REXML::Element))
     assert_equal(id.get_text.value, "urn:isbn:0262531283")
 
     rfr = ctx_obj.elements["ctx:referrer"]
-    assert(rfr.is_a?(REXML::Element))    
+    assert(rfr.is_a?(REXML::Element))
     id = rfr.elements['ctx:identifier']
     assert(id.is_a?(REXML::Element))
-    assert_equal(id.get_text.value, "info:sid/ebookco.com:bookreader") 
-    
+    assert_equal(id.get_text.value, "info:sid/ebookco.com:bookreader")
+
     svc = ctx_obj.elements["ctx:service-type"]
     assert(svc.is_a?(REXML::Element))
     mbv = svc.elements['ctx:metadata-by-val']
@@ -249,19 +249,19 @@ class ContextObjectTest < Test::Unit::TestCase
     abstract = metadata.elements['svc:abstract']
     assert(abstract.is_a?(REXML::Element))
     assert_equal(abstract.namespace('svc'), "info:ofi/fmt:xml:xsd:sch_svc")
-    
+
     assert_equal(abstract.get_text.value, "yes")
     #assert_match("svc_val_fmt=#{CGI.escape("info:ofi/fmt:kev:mtx:sch_svc")}", ctx.kev)
-    #assert_match("svc.abstract=yes", ctx.kev)    
-    
+    #assert_match("svc.abstract=yes", ctx.kev)
+
     #xml = File.new(data["context_objects"]["xml_doc"]).read
-    #ctx = OpenURL::ContextObject.new_from_xml(xml)  
-    #self.test_xml_values(ctx)    
+    #ctx = OpenURL::ContextObject.new_from_xml(xml)
+    #self.test_xml_values(ctx)
   end
 
 
   # deep_copy and import_context_object should NOT result in
-  # any shared objects between the two co's. 
+  # any shared objects between the two co's.
   def test_no_shared_objects_on_copy
     require 'yaml'
     data = YAML.load_file('test/test.yml')
@@ -271,14 +271,14 @@ class ContextObjectTest < Test::Unit::TestCase
 
     test_not_shared_objects( ctx_orig, ctx_deep_copied )
 
-    ctx_with_imported_data = 
+    ctx_with_imported_data =
       OpenURL::ContextObject.new_from_context_object( ctx_orig )
-    
+
     test_not_shared_objects( ctx_orig, ctx_with_imported_data )
-    
+
   end
-  
-  
+
+
   def test_to_hash
     require 'yaml'
     kev = YAML.load_file('test/test.yml')["context_objects"]["kev"]
@@ -287,17 +287,17 @@ class ContextObjectTest < Test::Unit::TestCase
     rft_metadata = ctx.referent.metadata
     rfe_metadata = ctx.referringEntity.metadata
     hash = ctx.to_hash
-    
+
     ["btitle", "genre", "aulast", "auinit", "date", "pub", "place"].each do | rft_key|
       assert_equal( hash["rft." + rft_key], rft_metadata[rft_key])
     end
-    
+
     ["btitle", "genre", "aulast", "date", "pub", "place", "isbn"].each do |rfe_key|
       assert_equal( hash ["rfe." + rfe_key], rfe_metadata[rfe_key])
     end
 
     assert_equal("yes", hash["svc.abstract"] )
-    
+
     # ids end up as arrays
     assert ( hash["rfr_id"].include?('info:sid/ebookco.com:bookreader'))
     assert( hash["rfe_id"].include?("urn:isbn:0262531283") )
@@ -307,17 +307,17 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal("info:ofi/fmt:kev:mtx:book", hash["rfe_val_fmt"])
 
 
-    
+
     assert_equal("info:ofi\/fmt:kev:mtx:ctx", hash["url_ctx_fmt"])
     assert_equal("2003-04-11T10:08:30TZD", hash["ctx_tim"])
-    # Don't understand what this one means. 
+    # Don't understand what this one means.
     assert_equal("10_8", hash["ctx_id"])
     assert_match("Z39.88-2004", hash["ctx_ver"])
     assert_match("info:ofi/enc:UTF-8", hash["ctx_enc"])
   end
 
 
-  
+
   def test_kev
     require 'yaml'
     data = YAML.load_file('test/test.yml')
@@ -335,12 +335,12 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_match("rft.date=1985",ctx.kev)
     assert_match("rfe.date=1995",ctx.kev)
     assert_match("rft.pub=Benjamins",ctx.kev)
-    assert_match("rfe.pub=The+MIT+Press",ctx.kev)    
+    assert_match("rfe.pub=The+MIT+Press",ctx.kev)
     assert_match("rft.place=Amsterdam%2C+Philadelphia",ctx.kev)
     assert_match("rfe.place=Cambridge%2C+Mass",ctx.kev)
     assert_match("rfe_id=#{CGI.escape('urn:isbn:0262531283')}", ctx.kev)
     assert_match("rfe.isbn=0262531283", ctx.kev)
-    assert_match("rfr_id=#{CGI.escape('info:sid/ebookco.com:bookreader')}", ctx.kev)    
+    assert_match("rfr_id=#{CGI.escape('info:sid/ebookco.com:bookreader')}", ctx.kev)
     assert_match("rft_val_fmt=#{CGI.escape("info:ofi/fmt:kev:mtx:book")}", ctx.kev)
     assert_match("rfe_val_fmt=#{CGI.escape("info:ofi/fmt:kev:mtx:book")}", ctx.kev)
     assert_match("svc_val_fmt=#{CGI.escape("info:ofi/fmt:kev:mtx:sch_svc")}", ctx.kev)
@@ -351,59 +351,59 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_match("ctx_ver=Z39.88-2004",ctx.kev)
     assert_match("ctx_enc=#{CGI.escape("info:ofi/enc:UTF-8")}", ctx.kev)
   end
-  
+
   def test_kev_01_pid
-      kev = "sid=CSA:eric-set-c&pid=%3CAN%3EED492558%3C%2FAN%3E%26%3CPY%3E2004%3C%2FPY%3E%26%3CAU%3EHsu%2C%20Jeng-yih%20Tim%3C%2FAU%3E&date=2004&genre=proceeding&aulast=Hsu&aufirst=Jeng-yih&auinitm=T&title=Reading%20without%20Teachers%3A%20Literature%20Circles%20in%20an%20EFL%20Classroom"   
-      ctx = OpenURL::ContextObject.new_from_kev(kev) 
+      kev = "sid=CSA:eric-set-c&pid=%3CAN%3EED492558%3C%2FAN%3E%26%3CPY%3E2004%3C%2FPY%3E%26%3CAU%3EHsu%2C%20Jeng-yih%20Tim%3C%2FAU%3E&date=2004&genre=proceeding&aulast=Hsu&aufirst=Jeng-yih&auinitm=T&title=Reading%20without%20Teachers%3A%20Literature%20Circles%20in%20an%20EFL%20Classroom"
+      ctx = OpenURL::ContextObject.new_from_kev(kev)
       assert_equal("<AN>ED492558</AN>&<PY>2004</PY>&<AU>Hsu, Jeng-yih Tim</AU>", ctx.referent.private_data)
   end
-  
+
   def test_set_openurl_ver
       # manually set 'illegal' openurl_ver is respected
-      kev = "sid=CSA:eric-set-c&pid=%3CAN%3EED492558%3C%2FAN%3E%26%3CPY%3E2004%3C%2FPY%3E%26%3CAU%3EHsu%2C%20Jeng-yih%20Tim%3C%2FAU%3E&date=2004&genre=proceeding&aulast=Hsu&aufirst=Jeng-yih&auinitm=T&title=Reading%20without%20Teachers%3A%20Literature%20Circles%20in%20an%20EFL%20Classroom"   
+      kev = "sid=CSA:eric-set-c&pid=%3CAN%3EED492558%3C%2FAN%3E%26%3CPY%3E2004%3C%2FPY%3E%26%3CAU%3EHsu%2C%20Jeng-yih%20Tim%3C%2FAU%3E&date=2004&genre=proceeding&aulast=Hsu&aufirst=Jeng-yih&auinitm=T&title=Reading%20without%20Teachers%3A%20Literature%20Circles%20in%20an%20EFL%20Classroom"
       ctx = OpenURL::ContextObject.new_from_kev(kev)
-      
+
       ctx.openurl_ver = "" # empty string!
-      
+
       kev = ctx.kev
-      
+
       assert_match(/url_ver=&/, kev)
       assert_match(/ctx_ver=&/, kev)
   end
-  
+
   def test_kev_res_id
     kev = "url_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&rfr_id=info:sid/aph&res_id=http://openurl.ac.uk/ukfed:dur.ac.uk&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.aulast=Rance&rft.aufirst=Philip&rft.atitle=De%20militari%20scientia »%20or%20Müller%20Fragment%20as%20a%20philological%20resource&rft.jtitle=Glotta&rft.stitle=Glotta&rft.date=2010&rft.volume=86&rft.spage=63&rft.epage=92&rft.issn=0017-1298&rft_id=info:oclcnum/1714662&rft.genre=article&sid=default:none"
     ctx = OpenURL::ContextObject.new_from_kev(kev)
     assert_equal("http://openurl.ac.uk/ukfed:dur.ac.uk", ctx.resolver.first.identifier)
   end
   protected
-  
+
   # Make sure ctx1 and ctx2 don't share the same data objects.
   # If they did, a change to one would change the other.
   def test_not_shared_objects(ctx1, ctx2)
     assert_not_equal( ctx1.referent.object_id, ctx2.referent.object_id );
     assert_not_equal( ctx1.referent.metadata.object_id, ctx2.referent.metadata.object_id )
-    
+
     original_ref_title = ctx1.referent.metadata['title']
     new_title = "new test title"
     # just ensure new uniqueness
-    new_title += original_ref_title if original_ref_title 
-    
+    new_title += original_ref_title if original_ref_title
+
     ctx1.referent.set_metadata('title', new_title)
 
     # That better not have changed ctx2
 
     assert_not_equal( new_title, ctx2.referent.metadata['title'])
-    
+
     # Now fix first title back to what it was originally, to have no
     # side-effects
     ctx1.referent.set_metadata('title', original_ref_title )
   end
-  
-  def test_kev_values(ctx)    
+
+  def test_kev_values(ctx)
     assert_equal(ctx.referent.format, 'book')
     assert_equal(ctx.referent.class, OpenURL::Book)
-    assert_equal(ctx.referent.metadata['btitle'], "Dépendances et niveaux de représentation en syntaxe")    
+    assert_equal(ctx.referent.metadata['btitle'], "Dépendances et niveaux de représentation en syntaxe")
     assert_equal(ctx.referent.metadata['genre'], 'book')
     assert_equal(ctx.referent.metadata['aulast'], 'Vergnaud')
     assert_equal(ctx.referent.metadata['auinit'], 'J.-R')
@@ -414,34 +414,34 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal(ctx.referringEntity.identifiers[0], 'urn:isbn:0262531283')
     assert_equal(ctx.referringEntity.format, 'book')
     assert_equal(ctx.referringEntity.class, OpenURL::Book)
-    assert_equal(ctx.referringEntity.metadata['genre'], 'book')  
+    assert_equal(ctx.referringEntity.metadata['genre'], 'book')
     assert_equal(ctx.referringEntity.metadata['aulast'], 'Chomsky')
     assert_equal(ctx.referringEntity.metadata['auinit'], 'N')
     assert_equal(ctx.referringEntity.metadata['btitle'], 'Minimalist Program')
     assert_equal(ctx.referringEntity.metadata['isbn'], '0262531283')
-    assert_equal(ctx.referringEntity.metadata['date'], '1995')    
+    assert_equal(ctx.referringEntity.metadata['date'], '1995')
     assert_equal(ctx.referringEntity.metadata['pub'], 'The MIT Press')
     assert_equal(ctx.referringEntity.metadata['place'], 'Cambridge, Mass')
     assert_equal(ctx.serviceType[0].format, 'sch_svc')
     assert_equal(ctx.serviceType[0].metadata['abstract'], 'yes')
     assert_equal(ctx.referrer.identifier, 'info:sid/ebookco.com:bookreader')
     assert_equal(ctx.referrer.identifiers[0], 'info:sid/ebookco.com:bookreader')
-    
+
     # Check administrative values
     assert_equal(ctx.admin["ctx_tim"]["value"], "2003-04-11T10:08:30TZD")
     assert_equal(ctx.admin["ctx_id"]["value"], "10_8")
     assert_equal(ctx.admin["ctx_enc"]["value"], "info:ofi/enc:UTF-8")
     assert_equal(ctx.admin["ctx_ver"]["value"], "Z39.88-2004")
   end
-  
-  def test_kev_hybrid_values(ctx)    
+
+  def test_kev_hybrid_values(ctx)
     assert(ctx.referrer.identifiers.index('info:sid/myid.com:mydb').is_a?(Fixnum))
     assert(ctx.referent.identifiers.index('info:doi/10.1126/science.275.5304.1320').is_a?(Fixnum))
     assert(ctx.referent.identifiers.index('info:pmid/9036860').is_a?(Fixnum))
     assert_match(/info:doi\/10\.1126\/science\.275\.5304\.1320|info:pmid\/9036860/, ctx.referent.identifier)
     assert_equal(ctx.referent.format, 'journal')
-    assert_equal(ctx.referent.metadata['atitle'], "Isolation of a common receptor for coxsackie B")    
-    assert_equal(ctx.referent.metadata['jtitle'], "Science")  
+    assert_equal(ctx.referent.metadata['atitle'], "Isolation of a common receptor for coxsackie B")
+    assert_equal(ctx.referent.metadata['jtitle'], "Science")
     assert_equal(ctx.referent.metadata['genre'], 'article')
     assert_equal(ctx.referent.metadata['aulast'], 'Bergelson')
     assert_equal(ctx.referent.metadata['auinit'], 'J')
@@ -449,20 +449,20 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal(ctx.referent.metadata['volume'], '275')
     assert_equal(ctx.referent.metadata['spage'], '1320')
     assert_equal(ctx.referent.metadata['epage'], '1323')
-    
+
     # Check administrative values
     assert_equal(ctx.admin["ctx_enc"]["value"], "info:ofi/enc:UTF-8")
     assert_equal(ctx.admin["ctx_ver"]["value"], "Z39.88-2004")
-  end  
-  
-  def test_kev_01_values(ctx)    
+  end
+
+  def test_kev_01_values(ctx)
     assert(ctx.referrer.identifiers.index('info:sid/myid:mydb').is_a?(Fixnum))
-    assert(ctx.referent.identifiers.index('info:doi/10.1126/science.275.5304.1320').is_a?(Fixnum))    
-    assert(ctx.referent.identifiers.index('info:pmid/9036860').is_a?(Fixnum))    
+    assert(ctx.referent.identifiers.index('info:doi/10.1126/science.275.5304.1320').is_a?(Fixnum))
+    assert(ctx.referent.identifiers.index('info:pmid/9036860').is_a?(Fixnum))
     assert_match(/info:doi\/10\.1126\/science\.275\.5304\.1320|info:pmid\/9036860/, ctx.referent.identifier)
     assert_equal(ctx.referent.format, 'journal')
-    assert_equal(ctx.referent.metadata['atitle'], "Isolation of a common receptor for coxsackie B")    
-    assert_equal(ctx.referent.metadata['title'], "Science")  
+    assert_equal(ctx.referent.metadata['atitle'], "Isolation of a common receptor for coxsackie B")
+    assert_equal(ctx.referent.metadata['title'], "Science")
     assert_equal(ctx.referent.metadata['genre'], 'article')
     assert_equal(ctx.referent.metadata['aulast'], 'Bergelson')
     assert_equal(ctx.referent.metadata['auinit'], 'J')
@@ -470,13 +470,13 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal(ctx.referent.metadata['volume'], '275')
     assert_equal(ctx.referent.metadata['spage'], '1320')
     assert_equal(ctx.referent.metadata['epage'], '1323')
-    
+
     # Check administrative values
     assert_equal(ctx.admin["ctx_enc"]["value"], "info:ofi/enc:UTF-8")
     assert_equal(ctx.admin["ctx_ver"]["value"], "Z39.88-2004")
-  end    
-  
-  def test_xml_values(ctx)    
+  end
+
+  def test_xml_values(ctx)
     assert(ctx.referent.is_a?(OpenURL::Journal))
     assert(ctx.referrer.identifiers.index('info:sid/metalib.com:PUBMED').is_a?(Fixnum))
     assert(ctx.referent.identifiers.index('info:doi/10.1364/OL.29.000017').is_a?(Fixnum))
@@ -484,8 +484,8 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_match(/info:doi\/10\.1364\/OL\.29\.000017|info:pmid\/14719646/, ctx.referent.identifier)
     assert(ctx.referringEntity.identifiers.index('info:doi/10.1063/1.1968421').is_a?(Fixnum))
     assert_equal(ctx.referent.format, 'journal')
-    assert_equal(ctx.referent.metadata['atitle'], "Temperature dependence of Brillouin frequency, power, and bandwidth in panda, bow-tie, and tiger polarization-maintaining fibers.")    
-    assert_equal(ctx.referent.metadata['stitle'], "Opt Lett")      
+    assert_equal(ctx.referent.metadata['atitle'], "Temperature dependence of Brillouin frequency, power, and bandwidth in panda, bow-tie, and tiger polarization-maintaining fibers.")
+    assert_equal(ctx.referent.metadata['stitle'], "Opt Lett")
     assert_equal(ctx.referent.metadata['jtitle'], "Optics letters")
     assert_equal(ctx.referent.metadata['issn'], "0146-9592")
     assert_equal(ctx.referent.metadata['aulast'], 'Yu')
@@ -506,7 +506,7 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal(ctx.admin["ctx_id"]["value"], "123")
     assert_equal(ctx.admin["ctx_enc"]["value"], "info:ofi/enc:UTF-8")
     assert_equal(ctx.admin["ctx_ver"]["value"], "Z39.88-2004")
-  end   
+  end
 
   def test_oai_dc_values(ctx)
     assert(ctx.referent.is_a?(OpenURL::DublinCore))
@@ -523,7 +523,7 @@ class ContextObjectTest < Test::Unit::TestCase
     assert_equal(ctx.referent.metadata["lang"], ["English"])
     assert_equal(ctx.referent.metadata["type"], ["journal article"])
   end
-  
+
   def test_marc_values(ctx)
     assert(ctx.referent.is_a?(OpenURL::Marc))
     assert(ctx.referent.marc.is_a?(MARC::Record))
@@ -532,6 +532,5 @@ class ContextObjectTest < Test::Unit::TestCase
   end
 
 
-    
-end
 
+end


### PR DESCRIPTION
This updates the gemspec to include newer versions of bundler
and it includes the gem versions of libs that used to be included
with ruby.

This also adds a GitHub Actions configuration for running the
tests on CI.